### PR TITLE
[CLEANUP] Transfer org ifmeo-hamburg-->ocean-uhh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ release: build
 		echo "GitHub release created as draft. Please edit and publish manually."; \
 	else \
 		echo "GitHub CLI (gh) not found. Please create release manually at:"; \
-		echo "https://github.com/ifmeo-hamburg/ctd-tools/releases/new"; \
+		echo "https://github.com/ocean-uhh/ctd-tools/releases/new"; \
 		echo "Tag: v$$VERSION"; \
 		echo "Upload files: dist/ctd_tools-$$VERSION.tar.gz and dist/ctd_tools-$$VERSION-py3-none-any.whl"; \
 	fi

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Start here to set up your local development environment: clone the repository, c
 1. **Clone the repo**  
 
    ```bash
-   git clone https://github.com/ifmeo-hamburg/ctd-tools.git
+   git clone https://github.com/ocean-uhh/ctd-tools.git
    cd ctd-tools
    ```
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -10,7 +10,7 @@ CTD Tools: Methods for working with oceanographic sensor data
 
 `ctd-tools` is a library to process data from oceanographic sensor formats.
 
-For recommendations or bug reports, please visit https://github.com/ifmeo-hamburg/ctd-tools/issues/new
+For recommendations or bug reports, please visit https://github.com/ocean-uhh/ctd-tools/issues/new
 
 
 .. toctree::
@@ -23,7 +23,7 @@ For recommendations or bug reports, please visit https://github.com/ifmeo-hambur
    :maxdepth: 2
    :caption: Help and reference
 
-   GitHub Repo <http://github.com/ifmeo-hamburg/ctd-tools>
+   GitHub Repo <http://github.com/ocean-uhh/ctd-tools>
    ctdtools
 
 .. toctree::

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,8 +76,8 @@ dev = [
 ]
 
 [project.urls]
-Homepage    = "https://ifmeo-hamburg.github.io/ctd-tools/"
-Source_Code = "https://github.com/ifmeo-hamburg/ctd-tools"
+Homepage    = "https://ocean-uhh.github.io/ctd-tools/"
+Source_Code = "https://github.com/ocean-uhh/ctd-tools"
 Download    = "https://pypi.org/project/ctd-tools/"
 
 [project.scripts]


### PR DESCRIPTION
Update links after changing from http://github.com/ifmeo-hamburg/ to http://github.com/ocean-uhh/